### PR TITLE
Run build verifications on PR through github actions

### DIFF
--- a/.github/workflows/gradle-build-pr.yml
+++ b/.github/workflows/gradle-build-pr.yml
@@ -1,0 +1,18 @@
+name: Run Gradle tests on PRs
+on: pull_request
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  gradle:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - uses: eskatos/gradle-command-action@v1
+        with:
+         arguments: build


### PR DESCRIPTION
Tested and verified here: https://github.com/warting/sdk/pull/1
and here: https://github.com/warting/sdk/actions/runs/283712304

Runs "./gradlew build" on both ubunto, linux and windows on each PR